### PR TITLE
Add Copy hex values button

### DIFF
--- a/data/ui/keys.ui
+++ b/data/ui/keys.ui
@@ -18,6 +18,23 @@
             </child>
           </object>
         </child>
+        <child>
+          <object class="GtkShortcutsGroup" id="copy">
+            <property name="title" translatable="yes" context="shortcut window">Copy</property>
+            <child>
+              <object class="GtkShortcutsShortcut" id="copy_text">
+                <property name="accelerator">&lt;ctrl&gt;e</property>
+                <property name="title" translatable="yes" context="shortcut window">Copy colors to clipboard</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut" id="copy_image">
+                <property name="accelerator">&lt;shift&gt;&lt;ctrl&gt;e</property>
+                <property name="title" translatable="yes" context="shortcut window">Copy colors image to clipboard</property>
+              </object>
+            </child>
+          </object>
+        </child>
       </object>
     </child>
   </object>

--- a/data/ui/menu.ui
+++ b/data/ui/menu.ui
@@ -4,8 +4,12 @@
   <menu id="menu">
     <section>
       <item>
-        <attribute name="label" translatable="yes">Export Colors as Image…</attribute>
-        <attribute name="action">win.action_export</attribute>
+        <attribute name="label" translatable="yes">Copy Colors to Clipboard</attribute>
+        <attribute name="action">win.action_export_txt</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">Copy Colors Image to Clipboard</attribute>
+        <attribute name="action">win.action_export_png</attribute>
       </item>
     </section>
     <section>

--- a/src/window.vala
+++ b/src/window.vala
@@ -54,12 +54,14 @@ namespace Colorway {
         public const string ACTION_PREFIX = "win.";
         public const string ACTION_ABOUT = "action_about";
         public const string ACTION_KEYS = "action_keys";
-        public const string ACTION_EXPORT = "action_export";
+        public const string ACTION_EXPORT_TXT = "action_export_txt";
+        public const string ACTION_EXPORT_PNG = "action_export_png";
         public static Gee.MultiMap<string, string> action_accelerators = new Gee.HashMultiMap<string, string> ();
         private const GLib.ActionEntry[] ACTION_ENTRIES = {
               {ACTION_ABOUT, action_about},
               {ACTION_KEYS, action_keys},
-              {ACTION_EXPORT, action_export},
+              {ACTION_EXPORT_TXT, action_export_txt},
+              {ACTION_EXPORT_PNG, action_export_png},
         };
 
         public Adw.Application app { get; construct; }
@@ -86,7 +88,8 @@ namespace Colorway {
             }
             app.set_accels_for_action("app.quit", {"<Ctrl>q"});
             app.set_accels_for_action("win.action_keys", {"<Ctrl>question"});
-            app.set_accels_for_action("win.action_export", {"<Ctrl>e"});
+            app.set_accels_for_action("win.action_export_txt", {"<Ctrl>e"});
+            app.set_accels_for_action("win.action_export_png", {"<Shift><Ctrl>e"});
 
             weak Gtk.IconTheme default_theme = Gtk.IconTheme.get_for_display (Gdk.Display.get_default ());
             default_theme.add_resource_path ("/io/github/lainsce/Colorway");
@@ -552,7 +555,39 @@ namespace Colorway {
             );
         }
 
-        public void action_export () {
+        public void action_export_txt () {
+            string export_txt = "";
+
+            export_txt += box.hex + "\n";
+
+            switch (color_rule_dropdown.get_active ()) {
+                case 2:
+                    export_txt += sbox.hex + "\n";
+                    break;
+                case 3:
+                case 4:
+                    export_txt += tbox.hex + "\n";
+                    break;
+            }
+
+            export_txt += ubox.hex + "\n";
+
+            // Put this ext_txt in clipboard
+            var display = Gdk.Display.get_default ();
+            unowned var clipboard = display.get_clipboard ();
+            clipboard.set_text (export_txt);
+
+            color_exported_label.set_sensitive(true);
+            color_exported_label.set_text(_("Colors copied to clipboard"));
+
+            Timeout.add(1000, () => {
+                color_exported_label.set_text("");
+                color_exported_label.set_sensitive(false);
+                return false;
+            });
+        }
+
+        public void action_export_png () {
             var snap = new Gtk.Snapshot ();
             mbox.snapshot (snap);
 
@@ -569,9 +604,9 @@ namespace Colorway {
             clipboard.set_texture (mt);
 
             color_exported_label.set_sensitive(true);
-            color_exported_label.set_text(_("Colors exported to clipboard."));
+            color_exported_label.set_text(_("Image copied to clipboard"));
 
-            Timeout.add(800, () => {
+            Timeout.add(1000, () => {
                 color_exported_label.set_text("");
                 color_exported_label.set_sensitive(false);
                 return false;


### PR DESCRIPTION
I thought this feature might be useful so I wrote a PR (I'll open an issue first next time 😅). Main idea is to copy hex values of colors in addition to copying the image of color combinations.

[Emulsion](https://github.com/lainsce/emulsion) already has something like that implemented so I used code from there as an Inspiration. I also extended the label timeout to 1s since I found it hard to read what's displayed there and changed the <kbd>Ctrl</kbd> e to be for copying text and <kbd>Shift</kbd> <kbd>Ctrl</kbd> e for copying the image.