### PR TITLE
Bound the chooser to the square picker

### DIFF
--- a/src/chooser.vala
+++ b/src/chooser.vala
@@ -122,18 +122,6 @@ public class Colorway.Chooser : Gtk.DrawingArea {
     }
 
     private static void xy_to_sv (double x, double y, out double s, out double v) {
-        if (x < 0) {
-            x = 0;
-        } else if (x > WIDTH) {
-            x = WIDTH;
-        }
-
-        if (y < 0) {
-            y = 0;
-        } else if (y > HEIGHT) {
-            y = HEIGHT;
-        }
-
         s = x / WIDTH;
         v = 1 - (y / HEIGHT);
     }
@@ -211,8 +199,24 @@ public class Colorway.Chooser : Gtk.DrawingArea {
         double _xpos, _ypos;
         drag.get_start_point (out _xpos, out _ypos);
 
-        xpos = _xpos + offset_x;
-        ypos = _ypos + offset_y;
+        double dx = _xpos + offset_x;
+        double dy = _ypos + offset_y;
+
+        if (dx > WIDTH) {
+            xpos = WIDTH;
+        } else if (dx < 0) {
+            xpos = 0;
+        } else {
+            xpos = dx;
+        }
+
+        if (dy > HEIGHT) {
+            ypos = HEIGHT;
+        } else if (dy < 0) {
+            ypos = 0;
+        } else {
+            ypos = _ypos + offset_y;
+        }
 
         double new_s, new_v;
         xy_to_sv (xpos, ypos, out new_s, out new_v);

--- a/src/chooser.vala
+++ b/src/chooser.vala
@@ -174,8 +174,7 @@ public class Colorway.Chooser : Gtk.DrawingArea {
         double _xpos, _ypos;
         gesture.get_point (null, out _xpos, out _ypos);
 
-        xpos = _xpos;
-        ypos = _ypos;
+        move_inbound(_xpos, _ypos, out xpos, out ypos);
 
         double new_s, new_v;
         xy_to_sv (xpos, ypos, out new_s, out new_v);
@@ -199,24 +198,7 @@ public class Colorway.Chooser : Gtk.DrawingArea {
         double _xpos, _ypos;
         drag.get_start_point (out _xpos, out _ypos);
 
-        double dx = _xpos + offset_x;
-        double dy = _ypos + offset_y;
-
-        if (dx > WIDTH) {
-            xpos = WIDTH;
-        } else if (dx < 0) {
-            xpos = 0;
-        } else {
-            xpos = dx;
-        }
-
-        if (dy > HEIGHT) {
-            ypos = HEIGHT;
-        } else if (dy < 0) {
-            ypos = 0;
-        } else {
-            ypos = _ypos + offset_y;
-        }
+        move_inbound(_xpos + offset_x, _ypos + offset_y, out xpos, out ypos);
 
         double new_s, new_v;
         xy_to_sv (xpos, ypos, out new_s, out new_v);
@@ -226,5 +208,23 @@ public class Colorway.Chooser : Gtk.DrawingArea {
 
     private static void gesture_drag_end (double offset_x, double offset_y) {
         drag.set_state (Gtk.EventSequenceState.DENIED);
+    }
+
+    private static void move_inbound(double xpos, double ypos, out double new_x, out double new_y) {
+        if (xpos > WIDTH) {
+            new_x = WIDTH;
+        } else if (xpos < 0) {
+            new_x = 0;
+        } else {
+            new_x = xpos;
+        }
+
+        if (ypos > HEIGHT) {
+            new_y = HEIGHT;
+        } else if (ypos < 0) {
+            new_y = 0;
+        } else {
+            new_y = ypos;
+        }
     }
 }


### PR DESCRIPTION
The color chooser (white circle) could be dragged out the bounds of the square picker. The code is refactored so the cirlce couldn't be dragged out of the bounds of the picker. The `xy_to_sv` function had most of it's logic removed since it's all handled in `gesture_drag_update`.